### PR TITLE
[feature] 내가 쓴 게시물 조회 api 추가

### DIFF
--- a/src/question/question.controller.ts
+++ b/src/question/question.controller.ts
@@ -108,6 +108,17 @@ export class QuestionController {
     return await this.questionService.getQuestionList(category);
   }
 
+  // 내가 쓴 게시물 조회
+  @Get('my')
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: '내가 쓴 질문 목록 조회', description: '로그인한 사용자가 작성한 질문들을 조회합니다.' })
+  @ApiResponse({ status: 200, type: [ListQuestionDto] })
+  async getMyQuestions(@Req() req: AuthenticatedRequest) {
+    const userId = req.user?.id;
+    if (!userId) throw new UnauthorizedException('로그인이 필요합니다.');
+    return await this.questionService.getMyQuestions(userId);
+  }
+
   // 질문 상세
   @Get(':id')
   @ApiOperation({ summary: '질문 상세 조회', description: '특정 질문의 상세 정보를 조회합니다.' })
@@ -142,4 +153,6 @@ export class QuestionController {
     if (!userId) throw new UnauthorizedException('로그인이 필요합니다.');
     return await this.questionService.reportQuestion(questionId, userId, reportDto);
   }
+  
+
 }

--- a/src/question/question.service.ts
+++ b/src/question/question.service.ts
@@ -8,6 +8,7 @@ import { ReportDto } from './dto/report-question.dto';
 
 @Injectable()
 export class QuestionService {
+  [x: string]: any;
     constructor(private readonly prisma: PrismaService) {}
 
     //질문 생성
@@ -131,5 +132,35 @@ export class QuestionService {
       },
     });
   }
+
+  // 내 질문 조회
+  async getMyQuestions(userId: number): Promise<ListQuestionDto[]> {
+    const questions = await this.prisma.question.findMany({
+      where: {
+        isDeleted: false,
+        userId: userId,
+      },
+      include: {
+        comments: true,
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+    });
+
+    return questions.map((q) => ({
+      id: q.id,
+      category: q.category as Category,
+      title: q.title,
+      content: q.content,
+      createdAt: q.createdAt,
+      isAnswered: q.comments.length > 0,
+      answerCount: q.comments.length,
+    }));
+  }
+
+
+
+
 }
 


### PR DESCRIPTION
## 📄 작업 내용

- 마이페이지에서 내가 작성한 질문 목록 조회 API (GET /questions/my) 추가
- Prisma 기반으로 내 질문 리스트 조회 구현
- 상세 페이지 진입 시 라우팅 충돌 문제 해결
<트러블슈팅4> https://www.notion.so/1-240800c9877b80f1a939fd64c5f80e77?source=copy_link


## 💬 공유사항 to 리뷰어

-GET /questions/my가 @Get(':id')보다 위에 있어야만 정상 동작하는 구조라 라우트 순서가 민감한 것 같슴다.. 상세 내용 트러블 슈팅 4번째 게시물에 작성하였습니다...

