### PR TITLE
[feature] 구글 번역 api 추가

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -10,6 +10,7 @@ import { ConfigModule } from '@nestjs/config';
 import { UserModule } from './user/user.module';
 import { OcrModule } from './ocr/ocr.module';
 import { AzureStorageModule } from './azure-storage/azure-storage.module';
+import { TranslateModule } from './translate/translate.module';
 @Module({
   imports: [
     ConfigModule.forRoot({
@@ -23,6 +24,7 @@ import { AzureStorageModule } from './azure-storage/azure-storage.module';
     CommentLikeModule,
     OcrModule,
     AzureStorageModule,
+    TranslateModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/question/question.controller.ts
+++ b/src/question/question.controller.ts
@@ -108,6 +108,17 @@ export class QuestionController {
     return await this.questionService.getQuestionList(category);
   }
 
+  // 내가 쓴 게시물 조회
+  @Get('my')
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: '내가 쓴 질문 목록 조회', description: '로그인한 사용자가 작성한 질문들을 조회합니다.' })
+  @ApiResponse({ status: 200, type: [ListQuestionDto] })
+  async getMyQuestions(@Req() req: AuthenticatedRequest) {
+    const userId = req.user?.id;
+    if (!userId) throw new UnauthorizedException('로그인이 필요합니다.');
+    return await this.questionService.getMyQuestions(userId);
+  }
+
   // 질문 상세
   @Get(':id')
   @ApiOperation({ summary: '질문 상세 조회', description: '특정 질문의 상세 정보를 조회합니다.' })
@@ -142,4 +153,6 @@ export class QuestionController {
     if (!userId) throw new UnauthorizedException('로그인이 필요합니다.');
     return await this.questionService.reportQuestion(questionId, userId, reportDto);
   }
+  
+
 }

--- a/src/question/question.service.ts
+++ b/src/question/question.service.ts
@@ -8,6 +8,7 @@ import { ReportDto } from './dto/report-question.dto';
 
 @Injectable()
 export class QuestionService {
+  [x: string]: any;
     constructor(private readonly prisma: PrismaService) {}
 
     //질문 생성
@@ -131,5 +132,35 @@ export class QuestionService {
       },
     });
   }
+
+  // 내 질문 조회
+  async getMyQuestions(userId: number): Promise<ListQuestionDto[]> {
+    const questions = await this.prisma.question.findMany({
+      where: {
+        isDeleted: false,
+        userId: userId,
+      },
+      include: {
+        comments: true,
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+    });
+
+    return questions.map((q) => ({
+      id: q.id,
+      category: q.category as Category,
+      title: q.title,
+      content: q.content,
+      createdAt: q.createdAt,
+      isAnswered: q.comments.length > 0,
+      answerCount: q.comments.length,
+    }));
+  }
+
+
+
+
 }
 

--- a/src/translate/translate.controller.spec.ts
+++ b/src/translate/translate.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TranslateController } from './translate.controller';
+
+describe('TranslateController', () => {
+  let controller: TranslateController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TranslateController],
+    }).compile();
+
+    controller = module.get<TranslateController>(TranslateController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/translate/translate.controller.ts
+++ b/src/translate/translate.controller.ts
@@ -1,0 +1,15 @@
+import { Controller, Post, Body, UseGuards } from '@nestjs/common';
+import { TranslateService } from './translate.service';
+import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
+
+@UseGuards(JwtAuthGuard)
+@Controller('translate')
+export class TranslateController {
+  constructor(private readonly translateService: TranslateService) {}
+
+  @Post()
+  async translate(@Body() body: { text: string; source: string; target: string }) {
+    const result = await this.translateService.translate(body.text, body.source, body.target);
+    return { translated: result };
+  }
+}

--- a/src/translate/translate.module.ts
+++ b/src/translate/translate.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { TranslateController } from './translate.controller';
+import { TranslateService } from './translate.service';
+import { HttpModule } from '@nestjs/axios';
+
+@Module({
+  imports: [HttpModule],
+  controllers: [TranslateController],
+  providers: [TranslateService]
+})
+export class TranslateModule {}

--- a/src/translate/translate.service.spec.ts
+++ b/src/translate/translate.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TranslateService } from './translate.service';
+
+describe('TranslateService', () => {
+  let service: TranslateService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [TranslateService],
+    }).compile();
+
+    service = module.get<TranslateService>(TranslateService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/translate/translate.service.ts
+++ b/src/translate/translate.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import { HttpService } from '@nestjs/axios';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class TranslateService {
+    constructor(
+        private readonly http: HttpService,
+        private readonly config: ConfigService,
+    ) {}
+
+    async translate(text: string, source: string, target: string): Promise<string> {
+    const apiKey = this.config.get<string>('GOOGLE_TRANSLATE_API_KEY');
+    const url = `https://translation.googleapis.com/language/translate/v2?key=${apiKey}`;
+
+    const body = {
+      q: text,
+      source,
+      target,
+      format: 'text',
+    };
+
+    const { data } = await this.http.axiosRef.post(url, body);
+    return data.data.translations[0].translatedText;
+  }
+
+
+}


### PR DESCRIPTION
## 📄 작업 내용

- Google Translate API를 백엔드에서 프록시 호출하는 /translate API 구현
- 프론트에서 직접 호출 방식 -> 서버 통해서 호출 
- API 키는 .env에 추가

## 💻 주요 코드 설명

- translate모듈/컨트롤러/서비스 파일 생성

`translate.module.ts`
- HttpModule, ConfigModule 등록



## 💬 공유사항 to 리뷰어

- 나중에 번역 API 교체하게 되면 백엔드 코드만 수정 하면 되연
- 구글 번역 api 키는 카카오톡으로 공유..!


