### PR TITLE
[fix] 내 질문 목록 응답에 user 포함, 전체 질문 응답 형식과 통일

### DIFF
--- a/src/question/dto/list-question.dto.ts
+++ b/src/question/dto/list-question.dto.ts
@@ -23,5 +23,23 @@ export class ListQuestionDto {
 
   @ApiProperty({ description: '답변 개수', example: 2 })
   answerCount: number;
+
+  // 전체 목록 형식이랑 동일시(작성자 정보 추가 -> 리팩토링시 삭제)
+  @ApiProperty({
+    description: '작성자 정보',
+    example: {
+      id: 1,
+      user_name: 'ohaii',
+      user_email: 'o@example.com',
+      user_role: true,
+    },
+  })
+  user: {
+    id: number;
+    user_name: string;
+    user_email: string;
+    user_role: boolean;
+  };
+  //
   
 }

--- a/src/question/question.controller.ts
+++ b/src/question/question.controller.ts
@@ -108,6 +108,17 @@ export class QuestionController {
     return await this.questionService.getQuestionList(category);
   }
 
+  // 내가 쓴 게시물 조회
+  @Get('my')
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: '내가 쓴 질문 목록 조회', description: '로그인한 사용자가 작성한 질문들을 조회합니다.' })
+  @ApiResponse({ status: 200, type: [ListQuestionDto] })
+  async getMyQuestions(@Req() req: AuthenticatedRequest) {
+    const userId = req.user?.id;
+    if (!userId) throw new UnauthorizedException('로그인이 필요합니다.');
+    return await this.questionService.getMyQuestions(userId);
+  }
+
   // 질문 상세
   @Get(':id')
   @ApiOperation({ summary: '질문 상세 조회', description: '특정 질문의 상세 정보를 조회합니다.' })
@@ -142,4 +153,6 @@ export class QuestionController {
     if (!userId) throw new UnauthorizedException('로그인이 필요합니다.');
     return await this.questionService.reportQuestion(questionId, userId, reportDto);
   }
+  
+
 }

--- a/src/question/question.controller.ts
+++ b/src/question/question.controller.ts
@@ -112,11 +112,43 @@ export class QuestionController {
   @Get('my')
   @UseGuards(JwtAuthGuard)
   @ApiOperation({ summary: '내가 쓴 질문 목록 조회', description: '로그인한 사용자가 작성한 질문들을 조회합니다.' })
-  @ApiResponse({ status: 200, type: [ListQuestionDto] })
+  @ApiResponse({
+    status: 200,
+    schema: {
+      example: {
+        user: {
+          id: 1,
+          username: 'user123',
+          email: 'user@example.com'
+        },
+        questions: [
+          {
+            id: 1,
+            title: '질문 제목',
+            content: '질문 내용',
+            category: 'study',
+            createdAt: '2024-08-04T00:00:00Z',
+            isAnswered: true,
+            answerCount: 3
+          }
+        ]
+      }
+    }
+  })
   async getMyQuestions(@Req() req: AuthenticatedRequest) {
-    const userId = req.user?.id;
-    if (!userId) throw new UnauthorizedException('로그인이 필요합니다.');
-    return await this.questionService.getMyQuestions(userId);
+    const user = req.user;
+    if (!user?.id) throw new UnauthorizedException('로그인이 필요합니다.');
+
+    const questions = await this.questionService.getMyQuestions(user.id);
+
+    return {
+      user: {
+        id: user.id,
+        username: user.username,
+        email: user.email,
+      },
+      questions,
+    };
   }
 
   // 질문 상세

--- a/src/question/question.controller.ts
+++ b/src/question/question.controller.ts
@@ -38,6 +38,7 @@ interface AuthenticatedRequest extends ExpressRequest {
     id: number;
     username?: string;
     email?: string;
+    isMentor?: boolean; //추가
   };
 }
 
@@ -109,46 +110,66 @@ export class QuestionController {
   }
 
   // 내가 쓴 게시물 조회
+  // @Get('my')
+  // @UseGuards(JwtAuthGuard)
+  // @ApiOperation({ summary: '내가 쓴 질문 목록 조회', description: '로그인한 사용자가 작성한 질문들을 조회합니다.' })
+  // @ApiResponse({
+  //   status: 200,
+  //   schema: {
+  //     example: {
+  //       user: {
+  //         id: 1,
+  //         username: 'user123',
+  //         email: 'user@example.com'
+  //       },
+  //       questions: [
+  //         {
+  //           id: 1,
+  //           title: '질문 제목',
+  //           content: '질문 내용',
+  //           category: 'study',
+  //           createdAt: '2024-08-04T00:00:00Z',
+  //           isAnswered: true,
+  //           answerCount: 3
+  //         }
+  //       ]
+  //     }
+  //   }
+  // })
+  // async getMyQuestions(@Req() req: AuthenticatedRequest) {
+  //   const user = req.user;
+  //   if (!user?.id) throw new UnauthorizedException('로그인이 필요합니다.');
+
+  //   const questions = await this.questionService.getMyQuestions(user.id);
+
+  //   return {
+  //     user: {
+  //       id: user.id,
+  //       username: user.username,
+  //       email: user.email,
+  //     },
+  //     questions,
+  //   };
+  // }
   @Get('my')
   @UseGuards(JwtAuthGuard)
   @ApiOperation({ summary: '내가 쓴 질문 목록 조회', description: '로그인한 사용자가 작성한 질문들을 조회합니다.' })
-  @ApiResponse({
-    status: 200,
-    schema: {
-      example: {
-        user: {
-          id: 1,
-          username: 'user123',
-          email: 'user@example.com'
-        },
-        questions: [
-          {
-            id: 1,
-            title: '질문 제목',
-            content: '질문 내용',
-            category: 'study',
-            createdAt: '2024-08-04T00:00:00Z',
-            isAnswered: true,
-            answerCount: 3
-          }
-        ]
-      }
-    }
-  })
+  @ApiResponse({ status: 200, type: [ListQuestionDto] })
   async getMyQuestions(@Req() req: AuthenticatedRequest) {
     const user = req.user;
     if (!user?.id) throw new UnauthorizedException('로그인이 필요합니다.');
 
     const questions = await this.questionService.getMyQuestions(user.id);
 
-    return {
+    return questions.map((q) => ({
+      ...q,
       user: {
         id: user.id,
-        username: user.username,
-        email: user.email,
+        user_name: user.username,
+        user_email: user.email,
+        user_role: user.isMentor,
       },
-      questions,
-    };
+    }));
   }
 
   // 질문 상세

--- a/src/question/question.service.ts
+++ b/src/question/question.service.ts
@@ -8,6 +8,7 @@ import { ReportDto } from './dto/report-question.dto';
 
 @Injectable()
 export class QuestionService {
+  [x: string]: any;
     constructor(private readonly prisma: PrismaService) {}
 
     //질문 생성
@@ -131,5 +132,35 @@ export class QuestionService {
       },
     });
   }
+
+  // 내 질문 조회
+  async getMyQuestions(userId: number): Promise<ListQuestionDto[]> {
+    const questions = await this.prisma.question.findMany({
+      where: {
+        isDeleted: false,
+        userId: userId,
+      },
+      include: {
+        comments: true,
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+    });
+
+    return questions.map((q) => ({
+      id: q.id,
+      category: q.category as Category,
+      title: q.title,
+      content: q.content,
+      createdAt: q.createdAt,
+      isAnswered: q.comments.length > 0,
+      answerCount: q.comments.length,
+    }));
+  }
+
+
+
+
 }
 

--- a/src/question/question.service.ts
+++ b/src/question/question.service.ts
@@ -134,7 +134,8 @@ export class QuestionService {
   }
 
   // 내 질문 조회
-  async getMyQuestions(userId: number): Promise<ListQuestionDto[]> {
+  // async getMyQuestions(userId: number): Promise<ListQuestionDto[]> {
+  async getMyQuestions(userId: number): Promise<Omit<ListQuestionDto, 'user'>[]> {
     const questions = await this.prisma.question.findMany({
       where: {
         isDeleted: false,


### PR DESCRIPTION
## 📄 작업 내용

- 내 질문 목록 조회시, 프론트에 user 정보까지 넘겨주도록 수정
- 전체 질문 목록 조회 할 때는 작성자 여러명이라 각 질문에 user 붙히는 방식,
내 질문 목록 조회 할 때는 user(자신) 하나에 질문 목록 달려오는 방식으로 수정

-> 현재 개발 편의상 전체 질문 목록 조회랑 같은 방식으로 최종 수정(리팩토링시 다시 위의 방식대로 되돌리기로)


## 💻 주요 코드 설명

`question.controller.ts`
- 내 질문 목록 조회 할 때는 user(자신) 하나에 질문 목록 달려오는 방식
- 리픽토링시 아래 코드 사용(현재 주석처리)

```typescript
// 내가 쓴 게시물 조회
  @Get('my')
  @UseGuards(JwtAuthGuard)
  @ApiOperation({ summary: '내가 쓴 질문 목록 조회', description: '로그인한 사용자가 작성한 질문들을 조회합니다.' })
  @ApiResponse({
    status: 200,
    schema: {
      example: {
        user: {
          id: 1,
          username: 'user123',
          email: 'user@example.com'
        },
        questions: [
          {
            id: 1,
            title: '질문 제목',
            content: '질문 내용',
            category: 'study',
            createdAt: '2024-08-04T00:00:00Z',
            isAnswered: true,
            answerCount: 3
          }
        ]
      }
    }
  })
  async getMyQuestions(@Req() req: AuthenticatedRequest) {
    const user = req.user;
    if (!user?.id) throw new UnauthorizedException('로그인이 필요합니다.');

    const questions = await this.questionService.getMyQuestions(user.id);

    return {
      user: {
        id: user.id,
        username: user.username,
        email: user.email,
      },
      questions,
    };
  }
```


```
//JSON 응답 구조
{
  "user": {
    "id": ,
    "username": ,
    "email": 
  },
  "questions": [
    {
      "id": ,
      "category": ,
      "title": ,
      "content": ,
      "createdAt": ,
      "isAnswered": ,
      "answerCount": 
    },
```
---

`question.controller.ts` , `list-question.dto.ts` , `question.service.ts`
```
//JSON 응답 구조
[
  {
    "id": ,
    "category": ,
    "title": ,
    "content": ,
    "createdAt": ,
    "isAnswered": ,
    "answerCount": ,
    "user": {
      "id": ,
      "user_name": ,
      "user_email": 
    }
  },
  {
    "id": ,
    "category": ,
    "title": ,
    "content": ,
    "createdAt": ,
    "isAnswered": ,
    "answerCount": ,
    "user": {
      "id": ,
      "user_name": ,
      "user_email": 
    }
  }
]
```
- **전체 질문 목록 조회 할 때(각 질문에 user 붙히는 방식)와 같은 방식으로 수정**
- **프론트 리팩토링시 위의 파일 주석처리 부분 사용 or 삭제하면 됨!!**




