### PR TITLE
채팅 부가 서비스-채팅 읽음 처리, 채팅방 숨기기(보이기)기능 추가

### DIFF
--- a/src/chat/chat.controller.ts
+++ b/src/chat/chat.controller.ts
@@ -39,7 +39,7 @@ export class ChatController {
   @ApiOperation({ summary: '내 채팅방 목록 조회' })
   async getUserChatRooms(@Req() req: Request) {
     const user = req.user as any; // JwtStrategy.validate()가 반환한 객체
-    return this.chatService.getUserChatRooms(Number(user.id));
+    return this.chatService.getUserChatRoomsWithUnread(Number(user.id));
   }
 
   // 채팅방 입장 -> 메세지 상세 내용 (페이지네이션)
@@ -87,8 +87,29 @@ export class ChatController {
   return this.chatService.reportMessage(Number(user.id), messageId, body.reason);
 }
 
+  // 채팅방 나가기(숨김)
+  @Post('rooms/:roomId/leave')
+  @UseGuards(JwtAuthGuard)
+  @ApiParam({ name: 'roomId', type: Number })
+  @ApiOperation({ summary: '채팅방 나가기(숨김 처리)' })
+  async leaveRoom(
+    @Req() req: Request,
+    @Param('roomId', ParseIntPipe) roomId: number,
+  ) {
+    const user = req.user as any;
+    return this.chatService.leaveRoom(Number(user.id), roomId);
+  }
 
-
-
-
+  // 채팅방 숨김 해제
+  @Post('rooms/:roomId/unhide')
+  @UseGuards(JwtAuthGuard)
+  @ApiParam({ name: 'roomId', type: Number })
+  @ApiOperation({ summary: '채팅방 숨김 해제' })
+  async unhideRoom(
+    @Req() req: Request,
+    @Param('roomId', ParseIntPipe) roomId: number,
+  ) {
+    const user = req.user as any;
+    return this.chatService.unhideRoom(Number(user.id), roomId);
+  }
 }

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -1,9 +1,8 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { CreateMessageDto } from './dto/create-message.dto';
 import { AzureStorageService } from 'src/common/azure-storage/azure-storage.service';
 import { Express } from 'express';
-import { NotFoundException } from '@nestjs/common';
 
 @Injectable()
 export class ChatService {
@@ -74,6 +73,49 @@ export class ChatService {
     });
   }
 
+  // 채팅방 목록 + 안 읽은 메시지 수 포함
+  async getUserChatRoomsWithUnread(userId: number) {
+    // 1) 내가 속한 방들 + 마지막 메시지 포함 조회 (숨김 방 제외)
+    const rooms = await this.prisma.chatRoom.findMany({
+      where: {
+        OR: [
+          { userAId: userId, isHiddenForUserA: false },
+          { userBId: userId, isHiddenForUserB: false },
+        ],
+      },
+      include: {
+        userA: { select: { id: true, userName: true } },
+        userB: { select: { id: true, userName: true } },
+        messages: { orderBy: { createdAt: 'desc' }, take: 1 },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    if (rooms.length === 0) return [] as Array<any>;
+
+    const roomIds = rooms.map(r => r.id);
+
+    // 2) 각 방의 unreadCount 계산 (내가 보낸 메시지 제외, isRead = false)
+    const unreadGroups = await this.prisma.message.groupBy({
+      by: ['roomId'],
+      where: {
+        roomId: { in: roomIds },
+        isRead: false,
+        senderId: { not: userId },
+      },
+      _count: { _all: true },
+    });
+
+    const unreadMap = new Map<number, number>();
+    for (const g of unreadGroups) unreadMap.set(g.roomId, g._count._all);
+
+    // 3) 결과 합치기
+    return rooms.map((r) => ({
+      ...r,
+      unreadCount: unreadMap.get(r.id) ?? 0,
+    }));
+  }
+
   // 채팅방 메시지 상세 조회(이전 대화 내용) - 페이지네이션
   async getMessagesDetail(roomId: number, take = 20, skip = 0) {
     return this.prisma.message.findMany({
@@ -108,5 +150,136 @@ export class ChatService {
         etcReason: null,       // 현재 DTO에서는 etcReason 미사용
       },
     });
+  }
+
+  // 여러 메시지를 읽음 처리 (내가 보낸 메시지는 제외)
+  async markMessagesAsRead(userId: number, messageIds: number[]) {
+    if (!Array.isArray(messageIds) || messageIds.length === 0) {
+      return { count: 0 };
+    }
+
+    return this.prisma.message.updateMany({
+      where: {
+        id: { in: messageIds },
+        senderId: { not: userId },
+      },
+      data: { isRead: true },
+    });
+  }
+
+  // 방 기준 여러 메시지 읽음 처리 + 마지막 읽은 메시지 포인터 갱신
+  async markMessagesAsReadInRoom(roomId: number, userId: number, messageIds: number[]) {
+    if (!Array.isArray(messageIds) || messageIds.length === 0) {
+      return { count: 0, lastReadMessageId: null };
+    }
+
+    // 1) 방 검증 및 참여자 확인
+    const room = await this.prisma.chatRoom.findUnique({
+      where: { id: roomId },
+      select: {
+        id: true,
+        userAId: true,
+        userBId: true,
+        lastReadMessageIdByA: true,
+        lastReadMessageIdByB: true,
+      },
+    });
+    if (!room) {
+      throw new NotFoundException('채팅방을 찾을 수 없습니다.');
+    }
+    const isUserA = room.userAId === userId;
+    const isUserB = room.userBId === userId;
+    if (!isUserA && !isUserB) {
+      throw new BadRequestException('해당 채팅방의 참여자가 아닙니다.');
+    }
+
+    // 2) 해당 방의 지정 메시지들만 읽음 처리 (내가 보낸 메시지는 제외)
+    const updateResult = await this.prisma.message.updateMany({
+      where: {
+        roomId,
+        id: { in: messageIds },
+        senderId: { not: userId },
+      },
+      data: { isRead: true },
+    });
+
+    // 3) 마지막 읽은 메시지 포인터 갱신 (최댓값 사용, 기존 값보다 작은 경우는 유지)
+    const maxId = Math.max(...messageIds);
+    let newPointer = maxId;
+
+    if (isUserA) {
+      const keep = room.lastReadMessageIdByA ?? 0;
+      newPointer = keep > maxId ? keep : maxId;
+      await this.prisma.chatRoom.update({
+        where: { id: roomId },
+        data: { lastReadMessageIdByA: newPointer },
+      });
+    } else if (isUserB) {
+      const keep = room.lastReadMessageIdByB ?? 0;
+      newPointer = keep > maxId ? keep : maxId;
+      await this.prisma.chatRoom.update({
+        where: { id: roomId },
+        data: { lastReadMessageIdByB: newPointer },
+      });
+    }
+
+    return { count: updateResult.count, lastReadMessageId: newPointer };
+  }
+  // === 방 나가기(숨김) ===
+  async leaveRoom(userId: number, roomId: number) {
+    const room = await this.prisma.chatRoom.findUnique({
+      where: { id: roomId },
+      select: { id: true, userAId: true, userBId: true, isHiddenForUserA: true, isHiddenForUserB: true },
+    });
+    if (!room) throw new NotFoundException('채팅방을 찾을 수 없습니다.');
+
+    if (room.userAId === userId) {
+      if (room.isHiddenForUserA) return { roomId, hiddenFor: 'A', alreadyHidden: true };
+      await this.prisma.chatRoom.update({
+        where: { id: roomId },
+        data: { isHiddenForUserA: true },
+      });
+      return { roomId, hiddenFor: 'A', alreadyHidden: false };
+    }
+
+    if (room.userBId === userId) {
+      if (room.isHiddenForUserB) return { roomId, hiddenFor: 'B', alreadyHidden: true };
+      await this.prisma.chatRoom.update({
+        where: { id: roomId },
+        data: { isHiddenForUserB: true },
+      });
+      return { roomId, hiddenFor: 'B', alreadyHidden: false };
+    }
+
+    throw new BadRequestException('해당 채팅방의 참여자가 아닙니다.');
+  }
+
+  // === 숨김 해제 ===
+  async unhideRoom(userId: number, roomId: number) {
+    const room = await this.prisma.chatRoom.findUnique({
+      where: { id: roomId },
+      select: { id: true, userAId: true, userBId: true, isHiddenForUserA: true, isHiddenForUserB: true },
+    });
+    if (!room) throw new NotFoundException('채팅방을 찾을 수 없습니다.');
+
+    if (room.userAId === userId) {
+      if (!room.isHiddenForUserA) return { roomId, unhiddenFor: 'A', alreadyVisible: true };
+      await this.prisma.chatRoom.update({
+        where: { id: roomId },
+        data: { isHiddenForUserA: false },
+      });
+      return { roomId, unhiddenFor: 'A', alreadyVisible: false };
+    }
+
+    if (room.userBId === userId) {
+      if (!room.isHiddenForUserB) return { roomId, unhiddenFor: 'B', alreadyVisible: true };
+      await this.prisma.chatRoom.update({
+        where: { id: roomId },
+        data: { isHiddenForUserB: false },
+      });
+      return { roomId, unhiddenFor: 'B', alreadyVisible: false };
+    }
+
+    throw new BadRequestException('해당 채팅방의 참여자가 아닙니다.');
   }
 }


### PR DESCRIPTION
# 1. 메세지 신고 기능 추가

- [x] 메세지 신고

- [x] 채팅방 나가기

- [x] 메세지 읽음 처리 + 남은 메세지 갯수

- [ ] 메세지 알람 => 나~중에


## 📄 작업 내용

- **채팅 읽음 처리 기능 구현**
  - 메시지를 읽음 처리, 마지막 읽은 메시지 포인터 갱신하는 로직 추가
  - 읽음 처리 => 내가 보낸 메시지는 제외하도록 필터링
  - 읽음 처리 후 groupBy를 활용하여 안 읽은 메시지 수를 계산, 채팅방 목록에 unreadCount 포함

- **채팅방 나가기 기능 구현**
  - 채팅방 삭제 말고 숨기기(isHiddenForUserA, isHiddenForUserB) 방식으로 구현
  - 숨기기 해제 API(unhideRoom)도 추가했슴 -> 나중에,, 숨긴 채팅 모아보기 페이지에서 다시 보이게 가능 --->>나중에......

## 💻 주요 코드 설명

`chat.service.ts`
- markMessagesAsReadInRoom
  - 방 검증, 참여자 확인
  - 마지막 읽은 메시지 포인터(lastReadMessageIdByA/B)를 최댓값으로 갱신
  - groupBy -> 각 방의 안 읽은 메시지 수를 계산

```typescript
const unreadGroups = await this.prisma.message.groupBy({
  by: ['roomId'],
  where: {
    roomId: { in: roomIds },
    isRead: false,
    senderId: { not: userId },
  },
  _count: { _all: true },
});
```

- 방 숨기기
  - isHiddenForUserA / isHiddenForUserB를 true로 설정 -> 목록에서 숨기기

## 💬 공유사항 to 리뷰어

- 숨김/해제 모두 JWT 인증 기반
- 노션 팀페이지 - api 명세서 추가 완료


---
- 읽음 처리 기능:  메시지의 isRead 상태 변경 + 마지막 읽은 메시지 포인터 갱신 및 unreadCount 계산
- 채팅방 나가기 == 숨기기 -> 모아보기 api 추가 하면 숨김 해제 api이용해서 목록 복구 가능
