### PR TITLE
fix: start script for Azure (node dist/main.js)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
-    "start": "nest start",
+    "start": "node dist/main.js",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",


### PR DESCRIPTION
## 📄 작업 내용

- App Service가 nest start로는 실행 안 돼서 node dist/main.js 로 변경
- develop → lsh 슬롯 GitHub Actions 배포 파이프라인 동작 확인 목적


## 💬 공유사항 to 리뷰어

- 아오 이거햇는데도 서버 안되면 되돌린다


